### PR TITLE
bench: report minimum + gcsample heavy benchmarks to cut CI variance

### DIFF
--- a/benchmarks/correlations.jl
+++ b/benchmarks/correlations.jl
@@ -59,8 +59,12 @@ function benchmark_correlations!(SUITE)
 
     SUITE["Correlations"]["two-time"] = BenchmarkGroup()
 
+    # Allocation-heavy: a full master-equation solve that rebuilds operators every
+    # ODE step (~0.5 GB / call). `gcsample=true` runs a GC before each sample so the
+    # timing isn't dominated by non-deterministic GC pauses carried over between
+    # samples, which otherwise gives this benchmark a ~4x run-to-run spread.
     SUITE["Correlations"]["two-time"]["single photon cavity"] =
-        @benchmarkable correlation_matrix($T, $ρt, $input_output, $Ls)
+        @benchmarkable correlation_matrix($T, $ρt, $input_output, $Ls) gcsample = true
 
     return nothing
 end

--- a/benchmarks/interaction_picture.jl
+++ b/benchmarks/interaction_picture.jl
@@ -40,8 +40,10 @@ function benchmark_interaction_picture!(SUITE)
 
     SUITE["Interaction Picture"]["coefficient matrix M"] = BenchmarkGroup()
 
+    # Allocation-heavy ODE solve: GC before each sample to stabilize the timing
+    # (see the note in runbenchmarks.jl).
     SUITE["Interaction Picture"]["coefficient matrix M"]["numerical (ODE)"] =
-        @benchmarkable solve_mode_evolution($A_uv, $T)
+        @benchmarkable solve_mode_evolution($A_uv, $T) gcsample = true
 
     SUITE["Interaction Picture"]["coefficient matrix M"]["analytical (2 equal modes)"] =
         @benchmarkable solve_mode_evolution_symmetric($u, $T)

--- a/benchmarks/runbenchmarks.jl
+++ b/benchmarks/runbenchmarks.jl
@@ -24,6 +24,14 @@ benchmark_correlations!(SUITE)
 
 BenchmarkTools.tune!(SUITE)
 results = BenchmarkTools.run(SUITE; verbose = true)
-display(median(results))
 
-BenchmarkTools.save("benchmarks_output.json", median(results))
+# Report the minimum rather than the median. The minimum is BenchmarkTools'
+# recommended estimator for tracking: measurement noise (GC pauses, scheduler
+# preemption, frequency scaling) is strictly additive, so the minimum is the
+# most reproducible estimate of the underlying cost and the least sensitive to
+# cross-runner variance. Allocation-heavy benchmarks additionally set
+# `gcsample=true` so each sample starts from a clean heap (see the individual
+# `@benchmarkable`s).
+display(minimum(results))
+
+BenchmarkTools.save("benchmarks_output.json", minimum(results))


### PR DESCRIPTION
The benchmark CI keeps flagging phantom regressions on `Correlations/two-time` (and the ODE interaction-picture one) because those benchmarks are GC-dominated. They allocate ~0.5 GB per call rebuilding operators every ODE step, spend ~half their runtime in garbage collection, and so swing ~4x run to run even on one machine. Comparing one noisy number against another across two different GitHub runners is all the "1.47x slower" alert ever was.

So this just changes how the timing is measured: save the `minimum` instead of the `median` (the minimum is the most reproducible number, since GC and scheduler noise only ever add time), and set `gcsample=true` on the two heavy ODE benchmarks so a GC runs before each sample instead of leaking between them.

Measured on the correlation benchmark, same machine, one session:

| config | min | median | max | max/min | GC% |
|---|---|---|---|---|---|
| before (median, no gcsample) | 167 ms | 225 ms | 483 ms | 2.9x | 52% |
| gcsample=true | 139 ms | 168 ms | 197 ms | 1.42x | 22% |

Reporting the minimum on top of that pins it near 140 ms instead of bouncing around 160 to 640 ms.

I left the fast ns/µs benchmarks alone (their minimum is already stable, 120 ns with or without gcsample), so a per-sample GC there would only cost samples for nothing. `tune!` doesn't help at this scale either; it just picks evals=1.

One heads-up: median to minimum is a one-time change, so the first run compares new minimums against the old median baseline and everything looks faster (nothing flagged), then the baseline resets and later runs are apples to apples.
