### PR TITLE
fix(translate): drop identically-zero terms to fix the correlation regression

### DIFF
--- a/src/translate.jl
+++ b/src/translate.jl
@@ -182,6 +182,21 @@ function _compile_coeff(c::Complex{Num}, vars...)
     return (vals...) -> g_re(vals...) + im * g_im(vals...)
 end
 
+# Fold `conj` applied to a numeric literal. After substituting a parameter to a
+# number, a coefficient can carry `conj(0.0)` (a real coupling set to zero) or
+# `conj(conj(0.0))` (from a cascade Hamiltonian's adjoint cross-term). Symbolics
+# does not fold these, so the term still looks nonzero and the time-dependent
+# closure re-evaluates it on every ODE step. Folding `conj`-of-a-number lets such
+# coefficients collapse to 0 so the term can be dropped. `conj` of a *symbolic*
+# (time) variable is left untouched.
+const _FOLD_NUM_CONJ = SymbolicUtils.Postwalk(
+    SymbolicUtils.PassThrough(SymbolicUtils.@rule conj(~x::(y -> y isa Number)) => conj(~x)),
+)
+_fold_num_conj(c::Complex{Num}) = Complex{Num}(
+    Num(_FOLD_NUM_CONJ(SymbolicUtils.unwrap(real(c)))),
+    Num(_FOLD_NUM_CONJ(SymbolicUtils.unwrap(imag(c)))),
+)
+
 # ── Per-term translation ──
 # Translate a single `(ops, coefficient)` term into a time-dependent function
 # `t -> op`. A concrete coefficient yields a constant function; a symbolic
@@ -250,29 +265,27 @@ function _translate_qo(
     op_ = substitute(op, parameter)
     iszero(op_) && return t -> op_type(0 * one(b))
 
-    pairs = collect(op_.arguments)
+    # Convert each coefficient to a foldable numeric form and drop terms that are
+    # identically zero after substitution. Without this, a coupling set to zero
+    # leaves an unfolded conj(0)/conj(conj(0)) factor, so the term survives and is
+    # needlessly rebuilt every ODE step (see `_fold_num_conj`).
+    pairs = Tuple{Any,Complex{Num}}[]
+    for (term, c_) in op_.arguments
+        c = _fold_num_conj(_coeff_num(c_))
+        iszero(c) && continue
+        push!(pairs, (term, c))
+    end
+    isempty(pairs) && return t -> op_type(0 * one(b))
+
     if length(pairs) == 1
         (term, c) = pairs[1]
-        return _translate_term(
-            term.ops,
-            _coeff_num(c),
-            b,
-            time_parameter,
-            operators,
-            op_type,
-        )
+        return _translate_term(term.ops, c, b, time_parameter, operators, op_type)
     end
 
     # Multi-term: combine via FunctionWrappers with a common concrete type so the
     # returned closure is type-stable. Inner products use `sparse` for a uniform type.
-    first_res = _translate_term(
-        pairs[1].first.ops,
-        _coeff_num(pairs[1].second),
-        b,
-        time_parameter,
-        operators,
-        sparse,
-    )
+    first_res =
+        _translate_term(pairs[1][1].ops, pairs[1][2], b, time_parameter, operators, sparse)
     OpType = typeof(first_res(0.0))
     FW = FunctionWrapper{OpType,Tuple{Float64}}
 
@@ -280,8 +293,8 @@ function _translate_qo(
         res =
             k == 1 ? first_res :
             _translate_term(
-                pairs[k].first.ops,
-                _coeff_num(pairs[k].second),
+                pairs[k][1].ops,
+                pairs[k][2],
                 b,
                 time_parameter,
                 operators,


### PR DESCRIPTION
The benchmark CI was right after all: there's a real regression in the `Correlations/two-time` (and time-dependent interaction-picture) benchmark, and it's not cross-runner noise. I tracked it down to `translate_qo`.

The time-dependent path kept terms whose coefficient is identically zero once the parameters are substituted. When a coupling is set to zero, the substitution leaves a `conj(0.0)` factor (or `conj(conj(0.0))` when the cascade Hamiltonian's second cross-term is built as `adjoint(X)`), and Symbolics doesn't fold either back to 0. So the term looked nonzero, survived into the compiled closure, and got re-evaluated (pulse interpolation + operator rebuild) on every single ODE step. The `g_v => 0` coupling in the correlation benchmark hits this directly.

The fix folds `conj` of a numeric literal in each coefficient and drops the ones that collapse to zero. `conj` of a symbolic time variable is left alone, so genuinely time-dependent complex couplings are untouched.

Measured on the correlation benchmark (same machine, `g_v = 0`):

| | allocations | memory | per-call H(t) |
|---|---|---|---|
| before (current sqav0.6) | 5.17M | 555 MB | 6128 B |
| after this PR | 2.78M | 373 MB | 2080 B |
| SQA 0.4.5 (old baseline) | 2.78M | 373 MB | 2400 B |

So it's back to the old 0.4.5 allocation level (actually a hair below per-call). Output is bit-identical (dropping identically-zero terms is exact), numeric SLH composition is unchanged since this doesn't touch the cascade, and translate construction time is unchanged. `test_translate` (37) and `test_correlations` (4) pass locally.

Worth noting: the earlier "it's just runner noise" framing on PRs #15/#18 was wrong, this was a genuine ~1.5-2x slowdown that the minimum/gcsample work correctly surfaced instead of hiding.
