### PR TITLE
fix: make SLH scattering field concretely typed

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "QuantumInputOutput"
 uuid = "18f9eda6-924c-47c7-a881-996695cfd7c6"
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 DataInterpolations = "82cc6244-b520-54b8-b5a6-8a565e85f1d0"

--- a/src/SLH.jl
+++ b/src/SLH.jl
@@ -95,10 +95,15 @@ SLH triple with scattering matrix `S`, Lindblad vector `L`, and Hamiltonian `H`.
 
 See also [`▷`](@ref), [`⊞`](@ref), [`feedback`](@ref)
 """
-struct SLH{N,ST,LT,HT}
-    scattering::SMatrix{N,N,ST}
+struct SLH{N,ST,LT,HT,L}
+    scattering::SMatrix{N,N,ST,L}
     lindblad::SVector{N,LT}
     hamiltonian::HT
+    function SLH{N,ST,LT,HT}(
+        S::SMatrix{N,N,ST,L}, lindblad::SVector{N,LT}, H::HT
+    ) where {N,ST,LT,HT,L}
+        return new{N,ST,LT,HT,L}(S, lindblad, H)
+    end
 end
 
 """

--- a/src/SLH.jl
+++ b/src/SLH.jl
@@ -100,7 +100,9 @@ struct SLH{N,ST,LT,HT,L}
     lindblad::SVector{N,LT}
     hamiltonian::HT
     function SLH{N,ST,LT,HT}(
-        S::SMatrix{N,N,ST,L}, lindblad::SVector{N,LT}, H::HT
+        S::SMatrix{N,N,ST,L},
+        lindblad::SVector{N,LT},
+        H::HT,
     ) where {N,ST,LT,HT,L}
         return new{N,ST,LT,HT,L}(S, lindblad, H)
     end


### PR DESCRIPTION
`SMatrix` carries a hidden length parameter `L` (the total element count `N*N`), so declaring the field as `SMatrix{N,N,ST}` left `L` free and rendered the `scattering` field abstract. This was caught by the `CheckConcreteStructs` (`Concretely typed`) test set.

Adds `L` to the struct and an inner constructor that infers it from the matrix, preserving the existing `SLH{N,ST,LT,HT}(...)` calling convention so no call sites needed changes. Existing dispatch sites (`SLH{N}`, `SLH{N,ST,LT,HT}`) are partial type applications and still match.